### PR TITLE
State: track glGetProgramResourceName

### DIFF
--- a/retrace/daemon/gldispatch/glframe_glhelper.cpp
+++ b/retrace/daemon/gldispatch/glframe_glhelper.cpp
@@ -81,6 +81,7 @@ static void *pEndPerfQueryINTEL = NULL;
 static void *pGetPerfQueryDataINTEL = NULL;
 static void *pGetProgramiv = NULL;
 static void *pGetProgramInfoLog = NULL;
+static void *pGetProgramResourceName = NULL;
 static void *pGetBooleanv = NULL;
 static void *pGetFloatv = NULL;
 static void *pBlendColor = NULL;
@@ -251,6 +252,8 @@ GlFunctions::Init(void *lookup_fn) {
   assert(pGetProgramiv);
   pGetProgramInfoLog = _GetProcAddress("glGetProgramInfoLog");
   assert(pGetProgramInfoLog);
+  pGetProgramResourceName = _GetProcAddress("glGetProgramResourceName");
+  assert(pGetProgramResourceName);
   pGetBooleanv = _GetProcAddress("glGetBooleanv");
   assert(pGetBooleanv);
   pGetFloatv = _GetProcAddress("glGetFloatv");
@@ -644,6 +647,21 @@ GlFunctions::GetProgramInfoLog(GLuint program, GLsizei bufSize,
   ((GETPROGRAMINFOLOG) pGetProgramInfoLog)(program, bufSize,
                                            length, infoLog);
 }
+
+void
+GlFunctions::GetProgramResourceName(GLuint program, GLenum programInterface,
+                                    GLuint index, GLsizei bufSize,
+                                    GLsizei *length, GLchar *name) {
+  typedef void (*GETPROGRAMRESOURCENAME)(GLuint program,
+                                         GLenum programInterface,
+                                         GLuint index, GLsizei bufSize,
+                                         GLsizei *length, GLchar *name);
+  ((GETPROGRAMRESOURCENAME) pGetProgramResourceName)(program,
+                                                     programInterface,
+                                                     index, bufSize,
+                                                     length, name);
+}
+
 
 void
 GlFunctions::GetBooleanv(GLenum pname, GLboolean *params) {

--- a/retrace/daemon/gldispatch/glframe_glhelper.hpp
+++ b/retrace/daemon/gldispatch/glframe_glhelper.hpp
@@ -112,6 +112,9 @@ class GlFunctions {
   static void GetProgramiv(GLuint program, GLenum pname, GLint *params);
   static void GetProgramInfoLog(GLuint program, GLsizei bufSize,
                                 GLsizei *length, GLchar *infoLog);
+  static void GetProgramResourceName(GLuint program, GLenum programInterface,
+                                     GLuint index, GLsizei bufSize,
+                                     GLsizei *length, GLchar *name);
 
   static void GetBooleanv(GLenum pname, GLboolean *params);
   static void GetFloatv(GLenum pname, GLfloat *params);

--- a/retrace/daemon/glframe_state.cpp
+++ b/retrace/daemon/glframe_state.cpp
@@ -32,6 +32,7 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "GL/gl.h"
 #include "GL/glext.h"
@@ -74,6 +75,7 @@ StateTrack::TrackMap::TrackMap() {
   lookup["glBindAttribLocation"] = &StateTrack::trackBindAttribLocation;
   lookup["glGetAttribLocation"] = &StateTrack::trackGetAttribLocation;
   lookup["glGetUniformLocation"] = &StateTrack::trackGetUniformLocation;
+  lookup["glGetProgramResourceName"] = &StateTrack::trackGetProgramResourceName;
   lookup["glGetUniformBlockIndex"] = &StateTrack::trackGetUniformBlockIndex;
   lookup["glUniformBlockBinding"] = &StateTrack::trackUniformBlockBinding;
   lookup["glBindFragDataLocation"] = &StateTrack::trackBindFragDataLocation;
@@ -771,6 +773,25 @@ StateTrack::trackGetUniformLocation(const Call &call) {
   const int location = GlFunctions::GetUniformLocation(program,
                                                        name.c_str());
   m_program_to_uniform_name[program][location] = name;
+}
+
+void
+StateTrack::trackGetProgramResourceName(const Call &call) {
+  const int call_program = call.args[0].value->toDouble();
+  const int program = glretrace::getRetracedProgram(call_program);
+  const int programInterface = call.args[1].value->toDouble();
+  const int index = call.args[2].value->toDouble();
+  const int bufSize = call.args[3].value->toDouble();
+
+  GLsizei length;
+  std::vector<char> name(bufSize);
+  GlFunctions::GetProgramResourceName(program,
+                                      programInterface,
+                                      index,
+                                      bufSize,
+                                      &length,
+                                      name.data());
+  m_program_to_uniform_name[program][index] = name.data();
 }
 
 void

--- a/retrace/daemon/glframe_state.hpp
+++ b/retrace/daemon/glframe_state.hpp
@@ -145,6 +145,7 @@ class StateTrack {
   void trackBindAttribLocation(const trace::Call &);
   void trackGetAttribLocation(const trace::Call &);
   void trackGetUniformLocation(const trace::Call &);
+  void trackGetProgramResourceName(const trace::Call &);
   void trackGetUniformBlockIndex(const trace::Call &);
   void trackUniformBlockBinding(const trace::Call &);
   void trackBindFragDataLocation(const trace::Call &);


### PR DESCRIPTION
Used by gfxbench5 aztec benchmark to identify uniform locations.